### PR TITLE
OP - added GET (show) endpoint for a single record in UCSBDiningCommonsMenuItem table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,68 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RestController
+@Slf4j
+
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+    
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all ucsb dining commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
+        Iterable<UCSBDiningCommonsMenuItem> UCSBDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findAll();
+        return UCSBDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Create a ucsb dining commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+        @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+        @Parameter(name="name") @RequestParam String name,
+        @Parameter(name="station") @RequestParam String station
+        )
+        {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+        ucsbDiningCommonsMenuItem.setName(name);
+        ucsbDiningCommonsMenuItem.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return savedUcsbDiningCommonsMenuItem;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -38,7 +38,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     @Autowired
     UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
 
-    @Operation(summary= "List all ucsb dining commons menu items")
+    @Operation(summary= "List all UCSB Dining Commons menu items")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
@@ -46,7 +46,7 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
         return UCSBDiningCommonsMenuItem;
     }
 
-    @Operation(summary= "Create a ucsb dining commons menu item")
+    @Operation(summary= "Create a UCSB Dining Commons menu item")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
@@ -64,5 +64,16 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
         UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
 
         return savedUcsbDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Get a single UCSB Dining Commons menu item")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return ucsbDiningCommonsMenuItem;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -14,7 +14,7 @@ import lombok.Builder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "ucsbdiningcommonsmenuitems")
+@Entity(name = "ucsbdiningcommonsmenuitem")
 public class UCSBDiningCommonsMenuItem {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, String> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 
 
 @Repository
-public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, String> {
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
 
 }

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItem-1",
+          "author": "MattP",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEM"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_6"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEM"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -3,7 +3,7 @@
       {
         "changeSet": {
           "id": "UCSBDiningCommonsMenuItem-1",
-          "author": "MattP",
+          "author": "OwenP",
           "preConditions": [
             {
               "onFail": "MARK_RAN"
@@ -27,7 +27,7 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_6"
+                        "primaryKeyName": "Creating_Table_For_UCSBDiningCommonsMenuItem"
                       },
                       "name": "ID",
                       "type": "BIGINT"

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -8,6 +8,7 @@ import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
 import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -131,4 +132,57 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+        // Tests for GET /api/UCSBDiningCommonsMenuItemid=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("bakedPestoPastaWithChicken")
+                                .station("entreeSpecials")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,134 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase  {
+    @MockBean
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/UCSBDiningCommonsMenuItem/all
+        
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbDiningCommonsMenuItem() throws Exception {
+
+        // arrange
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("bakedPestoPastaWithChicken")
+                .station("entreeSpecials")
+                .build();
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem2 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("tofuBanhMiSandwich(v)")
+                .station("entreeSpecials")
+                .build();
+
+        ArrayList<UCSBDiningCommonsMenuItem> expectedUCSBDiningCommonsMenuItem = new ArrayList<>();
+        expectedUCSBDiningCommonsMenuItem.addAll(Arrays.asList(ucsbDiningCommonsMenuItem1, ucsbDiningCommonsMenuItem2));
+
+        when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedUCSBDiningCommonsMenuItem);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedUCSBDiningCommonsMenuItem);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/UCSBDiningCommonsMenuItem/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsbDiningCommonsMenuItem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("bakedPestoPastaWithChicken")
+                .station("entreeSpecials")
+                .build();
+                
+        when(ucsbDiningCommonsMenuItemRepository.save(eq(ucsbDiningCommonsMenuItem1))).thenReturn(ucsbDiningCommonsMenuItem1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/UCSBDiningCommonsMenuItem/post?diningCommonsCode=ortega&name=bakedPestoPastaWithChicken&station=entreeSpecials")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItem1);
+        String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
Added GET functionality for a single record in the UCSBDiningCommonsMenuItem table by ID. Use to get info about a single menu item that already exists in the table by typing it's ID.

Closes #10 